### PR TITLE
Run android builds in parallel and minor improvements

### DIFF
--- a/.github/workflows/assemble_android.yml
+++ b/.github/workflows/assemble_android.yml
@@ -1,0 +1,100 @@
+name: 🤖 Assemble Android
+on:
+  workflow_call:
+    inputs:
+      godot-version:
+        type: string
+      jvm-version:
+        type: string
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux_assemble
+  cancel-in-progress: true
+
+jobs:
+  create-android-export-template:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v4.1
+        with:
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-swapfile: 'true'
+
+      - name: Clone Godot Engine
+        uses: actions/checkout@v4
+        with:
+          repository: godotengine/godot
+          ref: ${{ inputs.godot-version }}
+
+      - name: Clone Godot JVM module.
+        uses: actions/checkout@v4
+        with:
+          path: modules/kotlin_jvm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.jvm-version }}
+
+      - name: Setup python and scons
+        uses: ./.github/actions/godot-deps
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+
+      - name: Download android libs release arm32
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_release_android_arm32
+          path: "platform/android/java/lib/libs/"
+
+      - name: Download android libs debug arm32
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_debug_android_arm32
+          path: "platform/android/java/lib/libs/"
+
+      - name: Download android libs release arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_release_android_arm64
+          path: "platform/android/java/lib/libs/"
+
+      - name: Download android libs debug arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_debug_android_arm64
+          path: "platform/android/java/lib/libs/"
+
+      - name: Download android libs release x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_release_android_x86_64
+          path: "platform/android/java/lib/libs/"
+
+      - name: Download android libs debug x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_debug_android_x86_64
+          path: "platform/android/java/lib/libs/"
+
+      - name: Generate Godot templates
+        run: |
+          ls -l platform/android/java/lib/libs/
+          cd platform/android/java
+          ./gradlew generateGodotTemplates
+          cd ../../..
+          ls -l bin/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: export_template_android_all
+          path: "bin/*"

--- a/.github/workflows/assemble_export_templates.yml
+++ b/.github/workflows/assemble_export_templates.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   create-export-templates-tpz:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Create export template tpz
     steps:
       - name: Create templates folder

--- a/.github/workflows/assemble_export_templates.yml
+++ b/.github/workflows/assemble_export_templates.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   create-export-templates-tpz:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Create export template tpz
     steps:
       - name: Create templates folder

--- a/.github/workflows/assemble_ios.yml
+++ b/.github/workflows/assemble_ios.yml
@@ -31,11 +31,32 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Download ios export template binaries
+      - name: Download ios export template binaries debug
         uses: actions/download-artifact@v4
         with:
-          name: export_template_ios_all
+          name: export_template_debug_ios_arm64
           path: "./"
+
+      - name: Download ios export template binaries release
+        uses: actions/download-artifact@v4
+        with:
+          name: export_template_release_ios_arm64
+          path: "./"
+
+      - name: Setup MoltenVK build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            MoltenVk/Package
+            MoltenVk/External
+            MoltenVk/xcuserdata
+            MoltenVk/project.xcworkspace
+            MoltenVk/*.xccheckout
+            MoltenVk/*.xcscmblueprint
+            MoltenVk/build
+            MoltenVk/*.o
+            MoltenVk/*.a
+          key: assemble_ios_moltenvk_cache
 
       - name: Clone MoltenVK
         uses: actions/checkout@v4

--- a/.github/workflows/assemble_linux.yml
+++ b/.github/workflows/assemble_linux.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   create-linux-editor-zip:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/assemble_linux.yml
+++ b/.github/workflows/assemble_linux.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   create-linux-editor-zip:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -16,7 +16,40 @@ concurrency:
 jobs:
   android-template:
     runs-on: ubuntu-20.04
-    name: Build android template (all)
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Build android debug (arm32)
+            cache-name: export_template_debug_android_arm32
+            target: template_debug
+            sconsflags: arch=arm32
+
+          - name: Build android release (arm32)
+            cache-name: export_template_release_android_arm32
+            target: template_release
+            sconsflags: arch=arm32
+
+          - name: Build android debug (arm64)
+            cache-name: export_template_debug_android_arm64
+            target: template_debug
+            sconsflags: arch=arm64
+
+          - name: Build android release (arm64)
+            cache-name: export_template_release_android_arm64
+            target: template_release
+            sconsflags: arch=arm64
+
+          - name: Build android debug (x86_64)
+            cache-name: export_template_debug_android_x86_64
+            target: template_debug
+            sconsflags: arch=x86_64
+
+          - name: Build android release (x86_64)
+            cache-name: export_template_release_android_x86_64
+            target: template_release
+            sconsflags: arch=x86_64
 
     steps:
       - name: Maximize build space
@@ -41,7 +74,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle
@@ -63,50 +96,15 @@ jobs:
           platform: android
           target: template_release
 
-      - name: Compilation release (arm64)
+      - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
+          sconsflags: ${{ matrix.sconsflags }}
           platform: android
-          target: template_release
-
-      - name: Compilation release (x86_64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
-          platform: android
-          target: template_release
-
-      - name: Compilation debug (arm32)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm32
-          platform: android
-          target: template_debug
-
-      - name: Compilation debug (arm64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
-          platform: android
-          target: template_debug
-
-      - name: Compilation debug (x86_64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
-          platform: android
-          target: template_debug
-
-      - name: Generate Godot templates
-        run: |
-          cd platform/android/java
-          ./gradlew generateGodotTemplates
-          cd ../../..
-          ls -l bin/
+          target: ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: export_template_android_all
-          path: "bin/*"
+          name: ${{ matrix.cache-name }}
+          path: "platform/android/java/lib/libs/*"

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   android-template:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   android-template:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -12,7 +12,20 @@ concurrency:
 jobs:
   ios-template:
     runs-on: macos-latest
-    name: Build ios template (all)
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Build ios debug (arm64)
+            cache-name: export_template_debug_ios_arm64
+            target: template_debug
+            sconsflags: arch=arm64
+
+          - name: Build ios release (arm64)
+            cache-name: export_template_release_ios_arm64
+            target: template_release
+            sconsflags: arch=arm64
 
     steps:
       - name: Clone Godot Engine
@@ -33,22 +46,15 @@ jobs:
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
 
-      - name: Compilation release (arm64)
+      - name: ${{ matrix.name }}
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }}
+          sconsflags: ${{ matrix.sconsflags }}
           platform: ios
-          target: template_release
-
-      - name: Compilation debug (arm64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }}
-          platform: ios
-          target: template_debug
+          target: ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: export_template_ios_all
+          name: ${{ matrix.cache-name }}
           path: "bin/*"

--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-jvm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build Jvm artifacts
 
     steps:

--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-jvm:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Build Jvm artifacts
 
     steps:

--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jvm_intellij-plugin
-          path: kt/plugins/godot-intellij-plugin/build/distributions/godot-jvm-idea-plugin-*.zip
+          path: kt/plugins/godot-intellij-plugin/build/distributions/godot-intellij-plugin-*.zip
 
       - name: Upload plugins-common artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -26,20 +26,12 @@ jobs:
           remove-docker-images: 'true'
           remove-swapfile: 'true'
 
-      - name: Clone Godot Engine
-        uses: actions/checkout@v4
-        with:
-          repository: godotengine/godot
-          ref: ${{ inputs.godot-version }}
-
       - name: Clone Godot JVM module.
         uses: actions/checkout@v4
-        with:
-          path: modules/kotlin_jvm
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle
@@ -50,66 +42,66 @@ jobs:
       - name: Compilation
         # we build the release bootstrap jar here. Debug gets its own trigger later
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ build -Prelease
+          kt/gradlew -p kt/ build -Prelease buildPlugin
 
       - name: Upload api-generator artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_api-generator
-          path: modules/kotlin_jvm/kt/api-generator/build/libs/api-generator.jar
+          path: kt/api-generator/build/libs/api-generator.jar
 
       - name: Upload release bootstrap artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_godot-bootstrap_release
-          path: modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
-
-      - name: Upload debug bootstrap artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_debug
-          path: modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
+          path: kt/godot-library/build/libs/godot-bootstrap.jar
 
       - name: Upload entry-generator artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_entry-generator
-          path: modules/kotlin_jvm/kt/entry-generation/godot-entry-generator/build/libs/godot-entry-generator-*.jar
+          path: kt/entry-generation/godot-entry-generator/build/libs/godot-entry-generator-*.jar
 
       - name: Upload ksp-symbol-processor artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_ksp-symbol-processor
-          path: modules/kotlin_jvm/kt/entry-generation/godot-kotlin-symbol-processor/build/libs/godot-kotlin-symbol-processor-*.jar
+          path: kt/entry-generation/godot-kotlin-symbol-processor/build/libs/godot-kotlin-symbol-processor-*.jar
 
       - name: Upload gradle-plugin artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_gradle-plugin
-          path: modules/kotlin_jvm/kt/plugins/godot-gradle-plugin/build/libs/godot-gradle-plugin-*.jar
+          path: kt/plugins/godot-gradle-plugin/build/libs/godot-gradle-plugin-*.jar
 
       - name: Upload intellij-plugin artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_intellij-plugin
-          path: modules/kotlin_jvm/kt/plugins/godot-intellij-plugin/build/distributions/godot-jvm-idea-plugin-*.zip
+          path: kt/plugins/godot-intellij-plugin/build/distributions/godot-jvm-idea-plugin-*.zip
 
       - name: Upload plugins-common artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_plugins-common
-          path: modules/kotlin_jvm/kt/plugins/godot-plugins-common/build/libs/godot-plugins-common-*.jar
+          path: kt/plugins/godot-plugins-common/build/libs/godot-plugins-common-*.jar
 
       - name: Upload tools-common artifact
         uses: actions/upload-artifact@v4
         with:
           name: jvm_tools-common
-          path: modules/kotlin_jvm/kt/tools-common/build/libs/tools-common-*.jar
+          path: kt/tools-common/build/libs/tools-common-*.jar
 
       - name: Bootstrap debug compilation
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ build -Pdebug
+          kt/gradlew -p kt/ build -Pdebug
+
+      - name: Upload debug bootstrap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jvm_godot-bootstrap_debug
+          path: kt/godot-library/build/libs/godot-bootstrap.jar
 
       - name: Verify ide plugin
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ verifyPlugin
+          kt/gradlew -p kt/ verifyPlugin

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # use the oldest ubuntu version still available to github actions for the best backwards compatibility
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04 # use the oldest ubuntu version still available to github actions for the best backwards compatibility
+    runs-on: ubuntu-22.04 # use the oldest ubuntu version still available to github actions for the best backwards compatibility
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy_create_draft_release.yml
+++ b/.github/workflows/deploy_create_draft_release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: 17
 
       - name: Setup Gradle

--- a/.github/workflows/deploy_jvm.yml
+++ b/.github/workflows/deploy_jvm.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # run tests on oldest ubuntu we still support. See build_linux.yml
     name: ${{ matrix.name }}
     strategy:
       matrix:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -28,20 +28,12 @@ jobs:
             bootstrap-target: release
 
     steps:
-      - name: Clone Godot Engine
-        uses: actions/checkout@v4
-        with:
-          repository: godotengine/godot
-          ref: ${{ inputs.godot-version }}
-
       - name: Clone Godot JVM module.
         uses: actions/checkout@v4
-        with:
-          path: modules/kotlin_jvm
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle
@@ -53,22 +45,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: editor_${{ matrix.target }}_linux_x86_64
-          path: './bin'
+          path: './harness/tests/bin'
 
       - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
         uses: actions/download-artifact@v4
         with:
           name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './bin'
+          path: './harness/tests/bin'
 
       - name: Build tests project
         run: |
-          modules/kotlin_jvm/harness/tests/gradlew -p modules/kotlin_jvm/harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
 
       - name: Run Tests
         run: |
-          cd modules/kotlin_jvm/harness/tests/
-          chmod +x ../../../../bin/godot.*
+          cd harness/tests/
+          chmod +x bin/godot.*
           jlink --add-modules java.base,java.logging --output jvm/jre-amd64-linux
           ./gradlew runGutTests
         timeout-minutes: 30

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     strategy:
       matrix:

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test-linux-exports:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # run tests on oldest ubuntu we still support. See build_linux.yml
     name: ${{ matrix.name }}
     strategy:
       matrix:

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test-linux-exports:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     strategy:
       matrix:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -28,20 +28,12 @@ jobs:
             bootstrap-target: release
 
     steps:
-      - name: Clone Godot Engine
-        uses: actions/checkout@v4
-        with:
-          repository: godotengine/godot
-          ref: ${{ inputs.godot-version }}
-
       - name: Clone Godot JVM module.
         uses: actions/checkout@v4
-        with:
-          path: modules/kotlin_jvm
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle
@@ -53,22 +45,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: editor_${{ matrix.target }}_macos_universal
-          path: './bin'
+          path: './harness/tests/bin'
 
       - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
         uses: actions/download-artifact@v4
         with:
           name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './bin'
+          path: './harness/tests/bin'
 
       - name: Build tests project
         run: |
-          modules/kotlin_jvm/harness/tests/gradlew -p modules/kotlin_jvm/harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
 
       - name: Run Tests
         run: |
-          cd modules/kotlin_jvm/harness/tests/
-          chmod +x ../../../../bin/godot.*
+          cd harness/tests/
+          chmod +x bin/godot.*
           jlink --add-modules java.base,java.logging --output jvm/jre-arm64-macos
           ./gradlew runGutTests
         timeout-minutes: 30

--- a/.github/workflows/test_macos_exports.yml
+++ b/.github/workflows/test_macos_exports.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -28,20 +28,12 @@ jobs:
             bootstrap-target: release
 
     steps:
-      - name: Clone Godot Engine
-        uses: actions/checkout@v4
-        with:
-          repository: godotengine/godot
-          ref: ${{ inputs.godot-version }}
-
       - name: Clone Godot JVM module.
         uses: actions/checkout@v4
-        with:
-          path: modules/kotlin_jvm
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle
@@ -53,21 +45,21 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: editor_${{ matrix.target }}_windows_x86_64
-          path: './bin'
+          path: './harness/tests/bin'
 
       - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
         uses: actions/download-artifact@v4
         with:
           name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './bin'
+          path: './harness/tests/bin'
 
       - name: Build tests project
         run: |
-          modules/kotlin_jvm/harness/tests/gradlew -p modules/kotlin_jvm/harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
 
       - name: Run Tests
         run: |
-          cd modules/kotlin_jvm/harness/tests/
+          cd harness/tests/
           jlink --add-modules java.base,java.logging --output jvm/jre-amd64-windows
           ./gradlew runGutTests
         timeout-minutes: 30

--- a/.github/workflows/test_windows_exports.yml
+++ b/.github/workflows/test_windows_exports.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: adopt-hotspot
+          distribution: temurin
           java-version: ${{ inputs.jvm-version }}
 
       - name: Setup Gradle

--- a/.github/workflows/trigger_dev.yml
+++ b/.github/workflows/trigger_dev.yml
@@ -79,6 +79,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   build-linux:
     name: 🐧 Build Linux
@@ -98,6 +99,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-linux-exports:
     name: 🐧 Test Linux Exports
@@ -109,3 +111,4 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}

--- a/.github/workflows/trigger_dev.yml
+++ b/.github/workflows/trigger_dev.yml
@@ -79,7 +79,6 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
-      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   build-linux:
     name: 🐧 Build Linux

--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -70,6 +70,16 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
 
+  assemble-android:
+    name: 🤖 Assemble android
+    uses: ./.github/workflows/assemble_android.yml
+    needs:
+      - setup-build-variables
+      - build-android
+    with:
+      godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+
   assemble-macos:
     name: 🍎 Assemble macos
     uses: ./.github/workflows/assemble_macos.yml
@@ -122,7 +132,7 @@ jobs:
     uses: ./.github/workflows/assemble_export_templates.yml
     needs:
       - setup-build-variables
-      - build-android # uploads finished export template directly
+      - assemble-android
       - assemble-ios # export templates need to be packed into xcode project
       - build-linux # uploads finished export template directly
       - assemble-macos # export templates need to be packed into app

--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -29,7 +29,7 @@ jobs:
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
 
   build-android:
-    name: 🤖 Build and Assemble Android
+    name: 🤖 Build Android
     uses: ./.github/workflows/build_android.yml
     needs:
       - setup-build-variables

--- a/.github/workflows/trigger_on_push_master.yml
+++ b/.github/workflows/trigger_on_push_master.yml
@@ -75,6 +75,16 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
 
+  assemble-android:
+    name: 🤖 Assemble android
+    uses: ./.github/workflows/assemble_android.yml
+    needs:
+      - setup-build-variables
+      - build-android
+    with:
+      godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+
   assemble-macos:
     name: 🍎 Assemble macos
     uses: ./.github/workflows/assemble_macos.yml
@@ -127,7 +137,7 @@ jobs:
     uses: ./.github/workflows/assemble_export_templates.yml
     needs:
       - setup-build-variables
-      - build-android # uploads finished export template directly
+      - assemble-android
       - assemble-ios # export templates need to be packed into xcode project
       - build-linux # uploads finished export template directly
       - assemble-macos # export templates need to be packed into app

--- a/.github/workflows/trigger_on_push_master.yml
+++ b/.github/workflows/trigger_on_push_master.yml
@@ -34,7 +34,7 @@ jobs:
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
 
   build-android:
-    name: 🤖 Build and Assemble Android
+    name: 🤖 Build Android
     uses: ./.github/workflows/build_android.yml
     needs:
       - setup-build-variables

--- a/.github/workflows/trigger_on_tag.yml
+++ b/.github/workflows/trigger_on_tag.yml
@@ -41,7 +41,7 @@ jobs:
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
 
   build-android:
-    name: 🤖 Build and Assemble Android
+    name: 🤖 Build Android
     uses: ./.github/workflows/build_android.yml
     needs:
       - setup-build-variables

--- a/.github/workflows/trigger_on_tag.yml
+++ b/.github/workflows/trigger_on_tag.yml
@@ -82,6 +82,16 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
 
+  assemble-android:
+    name: 🤖 Assemble android
+    uses: ./.github/workflows/assemble_android.yml
+    needs:
+      - setup-build-variables
+      - build-android
+    with:
+      godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+
   assemble-macos:
     name: 🍎 Assemble macos
     uses: ./.github/workflows/assemble_macos.yml
@@ -134,7 +144,7 @@ jobs:
     uses: ./.github/workflows/assemble_export_templates.yml
     needs:
       - setup-build-variables
-      - build-android # uploads finished export template directly
+      - assemble-android
       - assemble-ios # export templates need to be packed into xcode project
       - build-linux # uploads finished export template directly
       - assemble-macos # export templates need to be packed into app
@@ -150,7 +160,7 @@ jobs:
     needs:
       - setup-build-variables
       - build-jvm
-      - build-android
+      - assemble-android
       - assemble-ios
       - assemble-linux
       - assemble-macos


### PR DESCRIPTION
This runs the android builds in parallel and adds some minor improvements to the CI/CD pipeline, like only defining a fixed linux version where necessary.